### PR TITLE
🍊 Sprint Clementine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "lexer",
+  "name": "captains-log",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Mon - 3/29/21 | Sprint Apple 🍎</title>
+    <title>Thu - 4/1/21 | Sprint Clementine 🍊</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body style="visibility: hidden;">
@@ -24,6 +24,14 @@
     <br />
     <h2>Release History:</h2>
     <ul>
+      <li>
+        <a href='#'>Thu - 4/1/21 | Sprint Clementine 🍊</a>
+        <ul>
+          <li>🛠 Fix package-lock.json</li>
+          <li>🎨 Add thumbnail to YoutubeLogs</li>
+        </ul>
+      </li>
+      <br />
       <li>
         <a href='https://github.com/r002/captains-log/pull/24'>Mon - 3/29/21 | Sprint Apple 🍎</a>
         <ul>

--- a/src/widgets/LogViewer.tsx
+++ b/src/widgets/LogViewer.tsx
@@ -116,24 +116,24 @@ type TYoutubeLog = {
 }
 
 const YoutubeLog = ({ id, dt, vidTitle, vid, bg }: TYoutubeLog) => {
-  function handleDelete () {
-    sendLogDelete(id)
-  }
+  // function handleDelete () {
+  //   sendLogDelete(id)
+  // }
 
   if (vidTitle.length > 58) {
     vidTitle = vidTitle.slice(0, 55) + '...'
   }
 
   return (
-    <FLogRecord title={dt.toString()} background={bg}>
+    <FLogRecord title={dt.toString()} background={bg} height='92px'>
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
         <div>
           <DtInput date={dt} logId={id} /> :: <a href={`https://youtu.be/${vid}`}>{vidTitle}</a>
         </div>
         <div>
-          {/* <img src={`https://i.ytimg.com/vi/${vid}/default.jpg`}
-            style={{ margin: '-10px' }} /> */}
-          <span onClick={handleDelete} style={{ cursor: 'pointer' }}>❌</span>
+          <img src={`https://i.ytimg.com/vi/${vid}/default.jpg`}
+            style={{ margin: '-10px' }} />
+          {/* <span onClick={handleDelete} style={{ cursor: 'pointer' }}>❌</span> */}
         </div>
       </div>
     </FLogRecord>


### PR DESCRIPTION
In this branch, I played around with the idea of embedding YT vid thumbnails directly in the logs themselves.  But I'm unhappy with the ascetics.  (TW thinks the thumbnails uglifies everything too!)  So I'm discarding this layout.  Will keep this PR around though just for future reference.

Also, FWIW, note-to-self:  Get better at design!  An ideal future state would be to mock everything up in PS **_first_** and then just implement _**that**_ version.  We'll get there.  Eventually. 😅  Right now, am still in a kinda "exploration/learning" phase and experimenting with different things.  Eg. Even if this sprint didn't ultimately contribute to `main`, by doing it, I learned all about the [YouTube V3 Data API](https://developers.google.com/youtube/v3/getting-started#Sample_Partial_Requests).

---

### Resources:

- https://developers.google.com/youtube/v3/getting-started#Sample_Partial_Requests
- https://developers.google.com/youtube/v3/docs/videos/list?apix_params=%7B%22part%22%3A%5B%22snippet%22%5D%2C%22id%22%3A%5B%228xg3vE8Ie_E%22%5D%7D&apix=true

---

### Rejected!

![image](https://user-images.githubusercontent.com/45280066/113517055-d4310400-954b-11eb-8f21-51814127d92d.png)